### PR TITLE
build: Add Meson build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+config.h
 batsignal
 batsignal.1
 *.o

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 
 NAME = batsignal
-VERSION != grep VERSION version.h | cut -d \" -f2
+VERSION = 1.3.2
 
 CC = cc
 RM = rm -f
@@ -22,13 +22,16 @@ LDFLAGS := $(LIBS) $(LDFLAGS_EXTRA)
 
 all: $(NAME) $(NAME).1
 
-$(NAME).o: version.h
+$(NAME).o: config.h
+
+config.h:
+	echo '#define VERSION "$(VERSION)"' > $@
 
 $(NAME): $(NAME).o
 	$(CC) -o $(NAME) $(NAME).o $(LDFLAGS)
 
-$(NAME).1: $(NAME).1.in version.h
-	$(SED) "s/VERSION/$(VERSION)/g" < $(NAME).1.in > $@
+$(NAME).1: $(NAME).1.in config.h
+	$(SED) "s/@VERSION@/$(VERSION)/g" < $(NAME).1.in > $@
 
 install: all
 	@echo Installing in $(DESTDIR)$(PREFIX)

--- a/batsignal.1.in
+++ b/batsignal.1.in
@@ -1,4 +1,4 @@
-.TH BATSIGNAL 1 batsignal\-VERSION
+.TH BATSIGNAL 1 batsignal\-@VERSION@
 .SH NAME
 batsignal \- battery monitor daemon
 .SH SYNOPSIS

--- a/batsignal.c
+++ b/batsignal.c
@@ -26,7 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include "version.h"
+
+#include "config.h"
 
 #define PROGNAME "batsignal"
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,35 @@
+project('batsignal', 'c',
+  license : 'ISC',
+  version : '1.3.2',
+  default_options : ['c_std=c99']
+)
+
+cc = meson.get_compiler('c')
+os = host_machine.system()
+
+libm_args = [] # ['-D', '_POSIX_C_SOURCE=200112L']
+libm = cc.find_library('m',
+  required : false)
+libm_ok = cc.has_function('round',
+  args: libm_args,
+  dependencies : [libm],
+  prefix : '#include <math.h>')
+assert(libm_ok)
+
+config = configuration_data()
+config.set_quoted('VERSION', meson.project_version())
+configure_file(
+  output : 'config.h',
+  configuration : config)
+
+executable('batsignal', files('batsignal.c'),
+  c_args: [libm_args],
+  dependencies : [libm, dependency('libnotify')],
+  install : true)
+
+configure_file(
+  configuration : {'VERSION': meson.project_version()},
+  input : files('batsignal.1.in'),
+  output: 'batsignal.1',
+  install : true,
+  install_dir : get_option('mandir') / 'man1')


### PR DESCRIPTION
Hi.
This PR adds support for Meson and [Muon](https://sr.ht/~lattis/muon/) (C99 implementation of Meson subset).
Meson & cie is more reliable and easier to validate.
So you only need a C99 compiler to build this project (muon+samurai).
WDYT?