### PR TITLE
check for capacity field

### DIFF
--- a/batsignal.c
+++ b/batsignal.c
@@ -384,7 +384,7 @@ void validate_options()
     errx(EXIT_FAILURE, "Option -f must be greater than %i.", lowlvl);
 }
 
-unsigned char is_battery(char *name)
+unsigned char is_type_battery(char *name)
 {
   FILE *file;
   char type[11] = "";
@@ -395,7 +395,28 @@ unsigned char is_battery(char *name)
     if (fscanf(file, "%10s", type) == 0) { /* Continue... */ }
     fclose(file);
   }
+
   return strcmp(type, "Battery") == 0;
+}
+
+unsigned char has_capacity_field(char *name)
+{
+  FILE *file;
+  int capacity = -1;
+
+  sprintf(attr_path, POWER_SUPPLY_SUBSYSTEM "/%s/capacity", name);
+  file = fopen(attr_path, "r");
+  if (file != NULL) {
+    if (fscanf(file, "%d", &capacity) == 0) { /* Continue... */ }
+    fclose(file);
+  }
+
+  return capacity >= 0;
+}
+
+unsigned char is_battery(char *name)
+{
+  return is_type_battery(name) != 0 && has_capacity_field(name) != 0;
 }
 
 void find_batteries()


### PR DESCRIPTION
Batsignal crashed with
```
batsignal: Could not read /sys/class/power_supply/hidpp_battery_2/capacity: No such file or directory
```

The reason was that there was no `capacity` field. But there was one  in `/sys/class/power_supply/BAT0`.

Added additional check for capacity field.