### PR TITLE
[Feature] Only show battery full notification once

### DIFF
--- a/batsignal.1.in
+++ b/batsignal.1.in
@@ -42,6 +42,9 @@ Battery danger LEVEL (default 2). 0 disables this level
 .B \-f LEVEL
 Battery full LEVEL (default 0). 0 disables this level
 .TP
+.B \-q
+Show the battery full notification only once per charge cycle
+.TP
 .B \-p
 Show a message when the battery begins charging or discharging
 .TP

--- a/main.c
+++ b/main.c
@@ -55,6 +55,7 @@ Options:\n\
                    (default: 2)\n\
     -f LEVEL       full battery LEVEL\n\
                    (default: disabled)\n\
+    -q             show battery full notification once\n\
     -p             show message when battery begins charging/discharging\n\
     -W MESSAGE     show MESSAGE when battery is at warning level\n\
     -C MESSAGE     show MESSAGE when battery is at critical level\n\

--- a/main.c
+++ b/main.c
@@ -105,6 +105,7 @@ int main(int argc, char *argv[])
     .battery_required = true,
     .show_notifications = true,
     .show_charging_msg = false,
+    .show_battery_full_once = false,
     .help = false,
     .version = false,
     .battery_names = NULL,
@@ -229,7 +230,9 @@ int main(int argc, char *argv[])
         notify(config.chargingmsg, NOTIFY_URGENCY_NORMAL, battery);
 
       } else {
-        battery.state = STATE_AC;
+        if (!config.show_battery_full_once || battery.state != STATE_FULL) {
+          battery.state = STATE_AC;
+        }
         close_notification();
       }
     }

--- a/options.c
+++ b/options.c
@@ -143,7 +143,7 @@ void parse_args(int argc, char *argv[], Config *config)
   signed int c;
   optind = 1;
 
-  while ((c = getopt(argc, argv, ":hvboiew:c:d:f:pW:C:D:F:P:U:M:Nn:m:a:I:")) != -1) {
+  while ((c = getopt(argc, argv, ":hvboiew:c:d:f:qpW:C:D:F:P:U:M:Nn:m:a:I:")) != -1) {
     switch (c) {
       case 'h':
         config->help = true;
@@ -172,6 +172,9 @@ void parse_args(int argc, char *argv[], Config *config)
       case 'f':
         config->full = strtoul(optarg, NULL, 10);
         config->fixed = true;
+        break;
+      case 'q':
+        config->show_battery_full_once = true;
         break;
       case 'p':
         config->show_charging_msg = 1;

--- a/options.h
+++ b/options.h
@@ -15,6 +15,7 @@ typedef struct Config {
   bool battery_required;
   bool show_notifications;
   bool show_charging_msg;
+  bool show_battery_full_once;
   bool help;
   bool version;
 


### PR DESCRIPTION
I added an option to only show the battery full notification once while the battery is full and charging. This reduces the spam I was experiencing while leaving my laptop plugged in. This resolves issue #35 . Since this is my first time working on this project I hope I correctly changed the man file and help menu entries. 