### PR TITLE
signal_handler(): Fix signature to comply with POSIX.1-2024

### DIFF
--- a/main.c
+++ b/main.c
@@ -82,8 +82,9 @@ void cleanup()
   }
 }
 
-void signal_handler()
+void signal_handler(int signum)
 {
+  (void) signum;
   exit(EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
When using this version of gcc:
`gcc (Debian 15.2.0-17) 15.2.0`

`make` fails with:
`main.c:133:19: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]`
`  133 |   signal(SIGTERM, signal_handler);`
`      |                   ^~~~~~~~~~~~~~`
`      |                   |`
`      |                   void (*)(void)`

Due to `signal_handler()` having the signature of `void (*)(void)`, whilst `signal()` function expects the second argument to be of type `void (*)(int)`.

This small patch is intended to fix this so that the project can be built with the latest version of gcc.